### PR TITLE
🧹 Remove debug print statements from Configuration.swift

### DIFF
--- a/OpenCone/Core/Configuration.swift
+++ b/OpenCone/Core/Configuration.swift
@@ -108,25 +108,22 @@ struct Configuration {
         return SecureSettingsStore.shared.getPineconeProjectId()
     }
 
-    /// Saves the OpenAI API key. (Placeholder - Prints confirmation).
+    /// Saves the OpenAI API key. (Placeholder).
     /// - Parameter key: The OpenAI API key to save.
     static func saveOpenAIAPIKey(_ key: String) {
         // Production implementation: Save securely to Keychain.
-        print("Placeholder: OpenAI API key saved (should use Keychain)")
     }
 
-    /// Saves the Pinecone API key. (Placeholder - Prints confirmation).
+    /// Saves the Pinecone API key. (Placeholder).
     /// - Parameter key: The Pinecone API key to save.
     static func savePineconeAPIKey(_ key: String) {
         // Production implementation: Save securely to Keychain.
-        print("Placeholder: Pinecone API key saved (should use Keychain)")
     }
 
-    /// Saves the Pinecone Project ID. (Placeholder - Prints confirmation).
+    /// Saves the Pinecone Project ID. (Placeholder).
     /// - Parameter id: The Pinecone Project ID to save.
     static func savePineconeProjectId(_ id: String) {
         // Production implementation: Save securely to Keychain.
-        print("Placeholder: Pinecone project ID saved (should use Keychain)")
     }
 
     // MARK: - Pinecone Location (Cloud/Region)


### PR DESCRIPTION
🎯 **What:** Removed placeholder debug print statements from `savePineconeAPIKey`, `saveOpenAIAPIKey`, and `savePineconeProjectId`. Also updated the corresponding documentation comments.
💡 **Why:** Cleans up console output and improves code health by removing unnecessary debug statements meant as placeholders.
✅ **Verification:** Visually inspected the code changes to ensure no functionality is broken and that the statements were removed correctly.
✨ **Result:** A cleaner console without placeholder output when running the application.

---
*PR created automatically by Jules for task [16557628036588089416](https://jules.google.com/task/16557628036588089416) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Update configuration placeholder save methods to no longer emit debug print statements and adjust their documentation comments accordingly.