### PR TITLE
🧹 Remove debug print statement from saveOpenAIAPIKey

### DIFF
--- a/OpenCone/Core/Configuration.swift
+++ b/OpenCone/Core/Configuration.swift
@@ -112,7 +112,6 @@ struct Configuration {
     /// - Parameter key: The OpenAI API key to save.
     static func saveOpenAIAPIKey(_ key: String) {
         // Production implementation: Save securely to Keychain.
-        print("Placeholder: OpenAI API key saved (should use Keychain)")
     }
 
     /// Saves the Pinecone API key. (Placeholder - Prints confirmation).


### PR DESCRIPTION
🎯 What: Removed the debug print statement from `saveOpenAIAPIKey` in `OpenCone/Core/Configuration.swift`.
💡 Why: Clean up console output.
✅ Verification: Tested visually and reviewed.
✨ Result: Clean console.

---
*PR created automatically by Jules for task [6914372870490952700](https://jules.google.com/task/6914372870490952700) started by @Gunnarguy*

## Summary by Sourcery

Remove a leftover debug print statement from the OpenAI API key save helper to clean up console output.