### PR TITLE
🔒 Fix plaintext secret exposure in UserDefaults migration

### DIFF
--- a/OpenCone/Core/Security/SecureSettingsStore.swift
+++ b/OpenCone/Core/Security/SecureSettingsStore.swift
@@ -140,18 +140,18 @@ final class SecureSettingsStore: @unchecked Sendable {
 
         if let legacyOpenAI, !legacyOpenAI.isEmpty, loadKeychainString(forKey: Key.openAIKey) == nil {
             _ = saveKeychainString(legacyOpenAI, forKey: Key.openAIKey)
-            UserDefaults.standard.removeObject(forKey: "openAIAPIKey")
         }
+        UserDefaults.standard.removeObject(forKey: "openAIAPIKey")
 
         if let legacyPineconeKey, !legacyPineconeKey.isEmpty, loadKeychainString(forKey: Key.pineconeKey) == nil {
             _ = saveKeychainString(legacyPineconeKey, forKey: Key.pineconeKey)
-            UserDefaults.standard.removeObject(forKey: "pineconeAPIKey")
         }
+        UserDefaults.standard.removeObject(forKey: "pineconeAPIKey")
 
         if let legacyProjectId, !legacyProjectId.isEmpty, loadKeychainString(forKey: Key.pineconeProjectId) == nil {
             _ = saveKeychainString(legacyProjectId, forKey: Key.pineconeProjectId)
-            UserDefaults.standard.removeObject(forKey: "pineconeProjectId")
         }
+        UserDefaults.standard.removeObject(forKey: "pineconeProjectId")
     }
 
     // MARK: - Keychain helpers


### PR DESCRIPTION
🎯 What: In the migration from UserDefaults to Keychain, if a legacy plain-text secret was already present in the Keychain, or if it was empty, the removeObject call for the plain text secret in UserDefaults was bypassed.

⚠️ Risk: This allowed the plain-text credentials to remain in UserDefaults, which is not a secure storage area, leaving the user's secrets potentially exposed to other applications or unauthorized access.

🛡️ Solution: Move the removeObject call outside of the if block that conditionally migrates to the Keychain, so that plain-text secrets are removed from UserDefaults unconditionally.

---
*PR created automatically by Jules for task [5080261707482398620](https://jules.google.com/task/5080261707482398620) started by @Gunnarguy*

## Summary by Sourcery

Bug Fixes:
- Always remove legacy plaintext API keys and related identifiers from UserDefaults regardless of whether migration to Keychain occurs.