### PR TITLE
🧹 Remove commented out preview view model

### DIFF
--- a/OpenCone/Features/ProcessingLog/ProcessingView.swift
+++ b/OpenCone/Features/ProcessingLog/ProcessingView.swift
@@ -233,9 +233,6 @@ struct LogExportView: View {
 }
 
 #Preview {
-    // Use PreviewData to create the sample view model
-    // let viewModel = PreviewData.sampleProcessingViewModel // Remove this line
-
     // No explicit return needed
     NavigationView {
         ProcessingView()  // Use the default initializer


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code from the `#Preview` block in `ProcessingView.swift`.
💡 **Why:** Clean up dead code, improving the maintainability and readability of the codebase.
✅ **Verification:** Verified the removal visually using the `read_file` tool and ran secret scanning tool locally. I was unable to run `xcodebuild test` because the build tools are missing in this environment, but removing commented-out lines is entirely safe and cannot break functionality.
✨ **Result:** Cleaned up the `#Preview` block.

---
*PR created automatically by Jules for task [8117511736376877912](https://jules.google.com/task/8117511736376877912) started by @Gunnarguy*

## Summary by Sourcery

Clean up the ProcessingView preview by removing obsolete commented-out code from the #Preview block in ProcessingView.swift.