### PR TITLE
🧹 Remove commented out destination struct

### DIFF
--- a/OpenCone/Features/Settings/SettingsNavigationRow.swift
+++ b/OpenCone/Features/Settings/SettingsNavigationRow.swift
@@ -77,9 +77,6 @@ struct SettingsNavigationRow_Previews: PreviewProvider {
     }
 
     static var previews: some View {
-        // Example destination view for preview - Removed from here
-        // struct SampleDestination: View { ... }
-
         NavigationView {
             OCCard(style: .standard) {
                 VStack(spacing: 0) {


### PR DESCRIPTION
🎯 **What:** Removed the commented out `SampleDestination` struct lines from `SettingsNavigationRow_Previews`.
💡 **Why:** Removing commented-out code reduces clutter and improves readability without changing functionality.
✅ **Verification:** Confirmed it's safe since no actual code was changed.
✨ **Result:** Cleaner code in `SettingsNavigationRow.swift`.

---
*PR created automatically by Jules for task [12949997686873445577](https://jules.google.com/task/12949997686873445577) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove unused commented-out sample destination view from the SettingsNavigationRow_Previews to reduce clutter.