### PR TITLE
🧪 [Test] Add unit tests for CredentialValidator.validateOpenAIKey

### DIFF
--- a/OpenConeTests/Core/Security/CredentialValidatorTests.swift
+++ b/OpenConeTests/Core/Security/CredentialValidatorTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import OpenCone
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("Handler is unavailable.")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class CredentialValidatorTests: XCTestCase {
+
+    var sut: CredentialValidator!
+
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        sut = CredentialValidator(session: session)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func testValidateOpenAIKey_EmptyKey_ReturnsInvalid() async {
+        let status = await sut.validateOpenAIKey("   ")
+        XCTAssertEqual(status, .invalid(message: "API key is empty"))
+    }
+
+    func testValidateOpenAIKey_Success_ReturnsValid() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        let status = await sut.validateOpenAIKey("sk-testkey")
+        XCTAssertEqual(status, .valid)
+    }
+
+    func testValidateOpenAIKey_Unauthorized_ReturnsInvalid() async {
+        MockURLProtocol.requestHandler = { request in
+            let json = """
+            {
+                "error": {
+                    "message": "Incorrect API key provided"
+                }
+            }
+            """
+            let data = json.data(using: .utf8)!
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let status = await sut.validateOpenAIKey("sk-testkey")
+        XCTAssertEqual(status, .invalid(message: "Incorrect API key provided"))
+    }
+
+    func testValidateOpenAIKey_RateLimited_ReturnsRateLimited() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 429, httpVersion: nil, headerFields: ["retry-after": "15"])!
+            return (response, Data())
+        }
+
+        let status = await sut.validateOpenAIKey("sk-testkey")
+        XCTAssertEqual(status, .rateLimited(retryAfterSeconds: 15))
+    }
+
+    func testValidateOpenAIKey_NetworkError_ReturnsInvalid() async {
+        MockURLProtocol.requestHandler = { _ in
+            throw NSError(domain: "TestError", code: -1001, userInfo: [NSLocalizedDescriptionKey: "The request timed out."])
+        }
+
+        let status = await sut.validateOpenAIKey("sk-testkey")
+        XCTAssertEqual(status, .invalid(message: "Network error: The request timed out."))
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for `CredentialValidator.validateOpenAIKey`. This addresses a gap in the test suite where the core logic for validating the OpenAI API key lacked automated verification.
📊 **Coverage:** The new test file `OpenConeTests/Core/Security/CredentialValidatorTests.swift` uses a `MockURLProtocol` to safely intercept and mock `URLSession` traffic. It covers the following scenarios:
  - Empty API keys
  - Successful validation (HTTP 200)
  - Unauthorized failure (HTTP 401)
  - Rate limited failure (HTTP 429)
  - Generic network errors
✨ **Result:** Increased test coverage for security-related credential validations. The tests are deterministic, run fast since they mock network requests, and will catch regressions if the validation logic is refactored. The Xcode project uses synchronized filesystem groups, so the new test file is automatically picked up by Xcode.

---
*PR created automatically by Jules for task [7286627390038232800](https://jules.google.com/task/7286627390038232800) started by @Gunnarguy*

## Summary by Sourcery

Tests:
- Introduce CredentialValidatorTests using a mock URL protocol to cover empty, valid, unauthorized, rate-limited, and network error scenarios for validateOpenAIKey.