### PR TITLE
🧹 Refactor ThemeManager to use Logger instead of print

### DIFF
--- a/OpenCone/Core/DesignSystem/ThemeManager.swift
+++ b/OpenCone/Core/DesignSystem/ThemeManager.swift
@@ -86,13 +86,13 @@ final class ThemeManager: ObservableObject, Sendable {
         }
 
         UIApplication.shared.setAlternateIconName(targetIcon) { error in
-            #if DEBUG
-            if let error = error {
-                print("[ThemeManager] Failed to set alternate icon: \(error.localizedDescription)")
-            } else {
-                print("[ThemeManager] Alternate icon set to: \(targetIcon ?? "primary")")
+            Task { @MainActor in
+                if let error = error {
+                    Logger.shared.log(level: .error, message: "Failed to set alternate icon: \(error.localizedDescription)", context: "ThemeManager")
+                } else {
+                    Logger.shared.log(level: .info, message: "Alternate icon set to: \(targetIcon ?? "primary")", context: "ThemeManager")
+                }
             }
-            #endif
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Removed `#if DEBUG` wrapped `print` statements in `ThemeManager.swift` and replaced them with `Logger.shared.log` wrapped in a `Task { @MainActor in }` block.

💡 **Why:** Using the centralized logger improves maintainability, ensuring that log statements adhere to the unified logging system, handle severity levels appropriately, and correctly render in the debug views (if applicable), avoiding generic `print` usage.

✅ **Verification:** Visually inspected the code changes to ensure correctness. Ran the Python secret scanner to ensure no secrets were inadvertently added. Checked that the unified logger correctly leverages `@MainActor` when required.

✨ **Result:** A more unified, cleaner way to log app icon change statuses without cluttering standard output unnecessarily and respecting the project's central logging mechanisms.

---
*PR created automatically by Jules for task [260033365126710830](https://jules.google.com/task/260033365126710830) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Replace DEBUG-only print statements in ThemeManager with Logger-based logging for alternate app icon changes.