### PR TITLE
⚡ Optimize document vector deletion to use batching

### DIFF
--- a/OpenCone/Features/Documents/DocumentsViewModel.swift
+++ b/OpenCone/Features/Documents/DocumentsViewModel.swift
@@ -351,41 +351,68 @@ final class DocumentsViewModel: ObservableObject {
             let defaultNamespace = await MainActor.run { self.selectedNamespace }
             var activeIndex = originalIndex
 
-            for document in documentsToRemove {
-                var vectorsRemoved = !document.isProcessed
-                var fileRemoved = false
+            struct TargetLocation: Hashable {
+                let indexName: String
+                let namespace: String?
+            }
 
-                let targetIndex = document.lastIndexedIndexName ?? originalIndex
-                let targetNamespace = document.lastIndexedNamespace ?? defaultNamespace
+            var groupedDocuments: [TargetLocation: [DocumentModel]] = [:]
+            var vectorsRemovedMap: [UUID: Bool] = [:]
+
+            for document in documentsToRemove {
+                vectorsRemovedMap[document.id] = !document.isProcessed
 
                 if document.isProcessed {
-                    do {
-                        if let indexName = targetIndex {
-                            if activeIndex != indexName {
-                                try await pineconeService.setCurrentIndex(indexName)
-                                activeIndex = indexName
-                            }
-                            let response = try await pineconeService.deleteVectors(
-                                ids: nil,
-                                filter: ["doc_id": ["$eq": document.documentId]],
-                                namespace: targetNamespace
-                            )
-                            if let deleted = response.deletedCount {
-                                logger.log(level: .info, message: "Deleted \(deleted) vectors", context: document.fileName)
-                            }
-                            vectorsRemoved = true
-                        } else {
-                            vectorsRemoved = false
-                            removalErrors.append("Missing Pinecone index for \(document.fileName); cannot delete vectors.")
-                        }
-                    } catch PineconeError.namespaceNotFound {
-                        vectorsRemoved = true
-                        logger.log(level: .warning, message: "Namespace not found during deletion; treating as already removed", context: document.fileName)
-                    } catch {
-                        vectorsRemoved = false
-                        removalErrors.append("Failed to delete vectors for \(document.fileName): \(error.localizedDescription)")
+                    let targetIndex = document.lastIndexedIndexName ?? originalIndex
+                    let targetNamespace = document.lastIndexedNamespace ?? defaultNamespace
+
+                    if let indexName = targetIndex {
+                        let location = TargetLocation(indexName: indexName, namespace: targetNamespace)
+                        groupedDocuments[location, default: []].append(document)
+                    } else {
+                        vectorsRemovedMap[document.id] = false
+                        removalErrors.append("Missing Pinecone index for \(document.fileName); cannot delete vectors.")
                     }
                 }
+            }
+
+            for (location, docs) in groupedDocuments {
+                do {
+                    if activeIndex != location.indexName {
+                        try await pineconeService.setCurrentIndex(location.indexName)
+                        activeIndex = location.indexName
+                    }
+
+                    let docIds = docs.map { $0.documentId }
+                    let response = try await pineconeService.deleteVectors(
+                        ids: nil,
+                        filter: ["doc_id": ["$in": docIds]],
+                        namespace: location.namespace
+                    )
+
+                    if let deleted = response.deletedCount {
+                        logger.log(level: .info, message: "Batch deleted \(deleted) vectors for \(docs.count) documents")
+                    }
+
+                    for doc in docs {
+                        vectorsRemovedMap[doc.id] = true
+                    }
+                } catch PineconeError.namespaceNotFound {
+                    for doc in docs {
+                        vectorsRemovedMap[doc.id] = true
+                        logger.log(level: .warning, message: "Namespace not found during deletion; treating as already removed", context: doc.fileName)
+                    }
+                } catch {
+                    for doc in docs {
+                        vectorsRemovedMap[doc.id] = false
+                        removalErrors.append("Failed to delete vectors for \(doc.fileName): \(error.localizedDescription)")
+                    }
+                }
+            }
+
+            for document in documentsToRemove {
+                let vectorsRemoved = vectorsRemovedMap[document.id] ?? false
+                var fileRemoved = false
 
                 if vectorsRemoved {
                     do {


### PR DESCRIPTION
💡 What: Changed the document deletion loop to group documents by index and namespace, and perform vector deletion in a single API call per group using Pinecone's `$in` operator.

🎯 Why: Previously, deleting multiple documents required an awaited sequential API call for each document. When clearing N documents from the same namespace/index, this meant N network roundtrips. Batching them drops this to 1 roundtrip, massively improving responsiveness and reducing API latency and potential rate limiting issues.

📊 Measured Improvement: Due to the environment lacking Xcode build tools and swift pm, a live benchmark couldn't be run. However, algorithmically, the number of sequential network requests has been reduced from O(N) to O(1) per namespace. For a typical deletion of 10+ documents, this translates to shaving seconds off the deletion operation latency.

---
*PR created automatically by Jules for task [1055945311804108282](https://jules.google.com/task/1055945311804108282) started by @Gunnarguy*

## Summary by Sourcery

Batch document vector deletions by index and namespace to reduce Pinecone API calls during document removal.

Enhancements:
- Group documents by index and namespace and delete their vectors in batches using a single Pinecone request per group.
- Track per-document vector deletion status via an ID map while preserving existing file deletion and error reporting behavior.