### PR TITLE
🧪 Add unit tests for PineconeService.healthCheck

### DIFF
--- a/OpenCone/Services/PineconeService.swift
+++ b/OpenCone/Services/PineconeService.swift
@@ -493,6 +493,7 @@ final class PineconeService {
         cfg.timeoutIntervalForRequest = 5.0
         cfg.timeoutIntervalForResource = 5.0
         cfg.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        cfg.protocolClasses = self.session.configuration.protocolClasses
         let shortSession = URLSession(configuration: cfg)
 
         do {

--- a/OpenCone/Services/PineconeService.swift
+++ b/OpenCone/Services/PineconeService.swift
@@ -75,7 +75,7 @@ final class PineconeService {
         let namespaceNames: [String]
     }
 
-    init(apiKey: String, projectId: String, configuration: PineconeServiceConfiguration = .default) {
+    init(apiKey: String, projectId: String, configuration: PineconeServiceConfiguration = .default, sessionConfiguration: URLSessionConfiguration = .default) {
         self.apiKey = apiKey
         self.projectId = projectId
         self.apiConfiguration = configuration
@@ -86,7 +86,7 @@ final class PineconeService {
         self.region = store.getPineconeRegion()
 
         // Configure session with better timeout and caching policies
-        let sessionConfiguration = URLSessionConfiguration.default
+        // let sessionConfiguration = URLSessionConfiguration.default
         sessionConfiguration.timeoutIntervalForRequest = 30.0
         sessionConfiguration.timeoutIntervalForResource = 60.0
         sessionConfiguration.requestCachePolicy = .reloadRevalidatingCacheData

--- a/OpenConeTests/PineconeServiceHealthCheckTests.swift
+++ b/OpenConeTests/PineconeServiceHealthCheckTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import OpenCone
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("Handler is unavailable.")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+    }
+}
+
+@MainActor
+final class PineconeServiceHealthCheckTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+        // Reset UserDefaults state if necessary for clean tests
+        UserDefaults.standard.removeObject(forKey: "pinecone.cachedIndexList")
+        UserDefaults.standard.removeObject(forKey: "pineconeCloud")
+        UserDefaults.standard.removeObject(forKey: "pineconeRegion")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testHealthCheck_NoIndexSelected() async {
+        let sut = PineconeService(apiKey: "test", projectId: "test")
+        // indexHost and currentIndex are nil by default
+
+        let result = await sut.healthCheck()
+
+        XCTAssertFalse(result)
+        XCTAssertFalse(sut.isCircuitOpen)
+    }
+
+    func testHealthCheck_Success() async throws {
+        let config = URLSessionConfiguration.default
+        config.protocolClasses = [MockURLProtocol.self]
+
+        let sut = PineconeService(apiKey: "test", projectId: "test")
+
+        // Setup handler to mock the index describe response so indexHost is set
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            if request.url?.absoluteString.contains("/indexes/") == true {
+                let json = """
+                {
+                    "name": "test-index",
+                    "host": "test-index.pinecone.io",
+                    "metric": "cosine",
+                    "dimension": 1536
+                }
+                """
+                return (response, json.data(using: .utf8)!)
+            }
+            if request.url?.absoluteString.contains("/describe_index_stats") == true {
+                let json = """
+                {
+                    "namespaces": {},
+                    "dimension": 1536,
+                    "indexFullness": 0,
+                    "totalVectorCount": 0
+                }
+                """
+                return (response, json.data(using: .utf8)!)
+            }
+            return (response, Data())
+        }
+
+
+        // First set current index
+        try await sut.setCurrentIndex("test-index")
+
+        let result = await sut.healthCheck()
+
+        XCTAssertTrue(result)
+        XCTAssertFalse(sut.isCircuitOpen)
+    }
+
+    func testHealthCheck_ServerError() async throws {
+        let sut = PineconeService(apiKey: "test", projectId: "test")
+
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.absoluteString.contains("/indexes/") == true {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                let json = """
+                {
+                    "name": "test-index",
+                    "host": "test-index.pinecone.io",
+                    "metric": "cosine",
+                    "dimension": 1536
+                }
+                """
+                return (response, json.data(using: .utf8)!)
+            }
+            if request.url?.absoluteString.contains("/describe_index_stats") == true {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+                return (response, Data())
+            }
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        // Set index
+        try await sut.setCurrentIndex("test-index")
+
+        // Need to hit health failure threshold to open circuit
+        // threshold is 2 according to PineconeService code
+        let result1 = await sut.healthCheck()
+        XCTAssertFalse(result1)
+        XCTAssertFalse(sut.isCircuitOpen) // threshold not reached yet (1 failure)
+
+        let result2 = await sut.healthCheck()
+        XCTAssertFalse(result2)
+        XCTAssertTrue(sut.isCircuitOpen) // threshold reached (2 failures)
+    }
+
+    func testHealthCheck_CircuitOpen() async throws {
+        let sut = PineconeService(apiKey: "test", projectId: "test")
+
+        MockURLProtocol.requestHandler = { request in
+            if request.url?.absoluteString.contains("/indexes/") == true {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                let json = """
+                {
+                    "name": "test-index",
+                    "host": "test-index.pinecone.io",
+                    "metric": "cosine",
+                    "dimension": 1536
+                }
+                """
+                return (response, json.data(using: .utf8)!)
+            }
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        try await sut.setCurrentIndex("test-index")
+
+        // Trigger 2 failures to open circuit
+        _ = await sut.healthCheck()
+        _ = await sut.healthCheck()
+
+        XCTAssertTrue(sut.isCircuitOpen)
+
+        // Change handler to return 200, but health check should still fail fast because circuit is open
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        let result = await sut.healthCheck()
+
+        XCTAssertFalse(result) // Failed fast
+        XCTAssertTrue(sut.isCircuitOpen) // Circuit still open
+    }
+}

--- a/OpenConeTests/PineconeServiceHealthCheckTests.swift
+++ b/OpenConeTests/PineconeServiceHealthCheckTests.swift
@@ -50,7 +50,9 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
     }
 
     func testHealthCheck_NoIndexSelected() async {
-        let sut = PineconeService(apiKey: "test", projectId: "test")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
         // indexHost and currentIndex are nil by default
 
         let result = await sut.healthCheck()
@@ -60,10 +62,10 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
     }
 
     func testHealthCheck_Success() async throws {
-        let config = URLSessionConfiguration.default
-        config.protocolClasses = [MockURLProtocol.self]
 
-        let sut = PineconeService(apiKey: "test", projectId: "test")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
 
         // Setup handler to mock the index describe response so indexHost is set
         MockURLProtocol.requestHandler = { request in
@@ -104,7 +106,9 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
     }
 
     func testHealthCheck_ServerError() async throws {
-        let sut = PineconeService(apiKey: "test", projectId: "test")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
 
         MockURLProtocol.requestHandler = { request in
             if request.url?.absoluteString.contains("/indexes/") == true {
@@ -142,7 +146,9 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
     }
 
     func testHealthCheck_CircuitOpen() async throws {
-        let sut = PineconeService(apiKey: "test", projectId: "test")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
 
         MockURLProtocol.requestHandler = { request in
             if request.url?.absoluteString.contains("/indexes/") == true {

--- a/OpenConeTests/PineconeServiceHealthCheckTests.swift
+++ b/OpenConeTests/PineconeServiceHealthCheckTests.swift
@@ -76,7 +76,11 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
                     "name": "test-index",
                     "host": "test-index.pinecone.io",
                     "metric": "cosine",
-                    "dimension": 1536
+                    "dimension": 1536,
+                    "status": {
+                        "state": "Ready",
+                        "ready": true
+                    }
                 }
                 """
                 return (response, json.data(using: .utf8)!)
@@ -86,6 +90,10 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
                 {
                     "namespaces": {},
                     "dimension": 1536,
+                    "status": {
+                        "state": "Ready",
+                        "ready": true
+                    },
                     "indexFullness": 0,
                     "totalVectorCount": 0
                 }
@@ -118,7 +126,11 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
                     "name": "test-index",
                     "host": "test-index.pinecone.io",
                     "metric": "cosine",
-                    "dimension": 1536
+                    "dimension": 1536,
+                    "status": {
+                        "state": "Ready",
+                        "ready": true
+                    }
                 }
                 """
                 return (response, json.data(using: .utf8)!)
@@ -158,7 +170,11 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
                     "name": "test-index",
                     "host": "test-index.pinecone.io",
                     "metric": "cosine",
-                    "dimension": 1536
+                    "dimension": 1536,
+                    "status": {
+                        "state": "Ready",
+                        "ready": true
+                    }
                 }
                 """
                 return (response, json.data(using: .utf8)!)


### PR DESCRIPTION
🎯 What: Added a test file PineconeServiceHealthCheckTests.swift testing missing health check logic. Also modified PineconeService.swift ephemeral session to inherit custom protocols so that it can be successfully intercepted using MockURLProtocol during tests.
📊 Coverage:
- 'No index selected' handles false health
- Health check success parsing for 200 responses
- Health check failure handling for 500 responses
- Circuit breaker opening after threshold limit is hit and failing fast if the circuit is already open.
✨ Result: Enhanced confidence in Pinecone circuit breaker behavior.

---
*PR created automatically by Jules for task [9558662724165214560](https://jules.google.com/task/9558662724165214560) started by @Gunnarguy*

## Summary by Sourcery

Add unit tests to verify PineconeService health check behavior and adjust the ephemeral URLSession configuration to support protocol-based request interception during testing.

Enhancements:
- Configure the short-lived URLSession used by PineconeService to reuse the main session's protocol classes for compatibility with custom URLProtocol-based mocking.

Tests:
- Add PineconeServiceHealthCheckTests covering success, failure, and circuit breaker scenarios for healthCheck, including no-index-selected behavior.