### PR TITLE
🧹 Remove unused localSearch and cosineSimilarity functions

### DIFF
--- a/OpenCone/Services/EmbeddingService.swift
+++ b/OpenCone/Services/EmbeddingService.swift
@@ -188,26 +188,6 @@ final class EmbeddingService: Sendable {
         return embedding
     }
 
-    /// Calculate cosine similarity between two vectors
-    /// - Parameters:
-    ///   - a: First vector
-    ///   - b: Second vector
-    /// - Returns: Cosine similarity score
-    func cosineSimilarity(a: [Float], b: [Float]) -> Float {
-        guard a.count == b.count, !a.isEmpty else {
-            return 0
-        }
-
-        let dotProduct = zip(a, b).map { $0 * $1 }.reduce(0, +)
-        let magnitudeA = sqrt(a.map { $0 * $0 }.reduce(0, +))
-        let magnitudeB = sqrt(b.map { $0 * $0 }.reduce(0, +))
-
-        guard magnitudeA > 0, magnitudeB > 0 else {
-            return 0
-        }
-
-        return dotProduct / (magnitudeA * magnitudeB)
-    }
 
     /// Convert embeddings to Pinecone format
     /// - Parameter embeddings: Array of EmbeddingModel objects
@@ -222,22 +202,6 @@ final class EmbeddingService: Sendable {
         }
     }
 
-    /// Local search when Pinecone is not available (for small datasets)
-    /// - Parameters:
-    ///   - queryEmbedding: Query vector embedding
-    ///   - embeddings: Array of EmbeddingModel objects
-    ///   - topK: Number of results to return
-    /// - Returns: Array of search results with similarities
-    func localSearch(queryEmbedding: [Float], embeddings: [EmbeddingModel], topK: Int) -> [(EmbeddingModel, Float)] {
-        let similarities = embeddings.map { embedding in
-            (embedding, cosineSimilarity(a: queryEmbedding, b: embedding.vector))
-        }
-
-        return similarities
-            .sorted { $0.1 > $1.1 } // Sort by similarity (descending)
-            .prefix(topK) // Take only top K results
-            .map { ($0.0, $0.1) }
-    }
 
     // MARK: - Metadata Helpers
 

--- a/OpenConeTests/Core/Security/CredentialValidatorTests.swift
+++ b/OpenConeTests/Core/Security/CredentialValidatorTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import OpenCone
 
-final class MockURLProtocol: URLProtocol {
+private final class MockURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {

--- a/OpenConeTests/Core/Security/CredentialValidatorTests.swift
+++ b/OpenConeTests/Core/Security/CredentialValidatorTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import OpenCone
 
-private final class MockURLProtocol: URLProtocol {
+private final class CredentialValidatorMockURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -13,7 +13,7 @@ private final class MockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
+        guard let handler = CredentialValidatorMockURLProtocol.requestHandler else {
             fatalError("Handler is unavailable.")
         }
 
@@ -38,13 +38,13 @@ final class CredentialValidatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
+        configuration.protocolClasses = [CredentialValidatorMockURLProtocol.self]
         let session = URLSession(configuration: configuration)
         sut = CredentialValidator(session: session)
     }
 
     override func tearDown() {
-        MockURLProtocol.requestHandler = nil
+        CredentialValidatorMockURLProtocol.requestHandler = nil
         sut = nil
         super.tearDown()
     }
@@ -55,7 +55,7 @@ final class CredentialValidatorTests: XCTestCase {
     }
 
     func testValidateOpenAIKey_Success_ReturnsValid() async {
-        MockURLProtocol.requestHandler = { request in
+        CredentialValidatorMockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data())
         }
@@ -65,7 +65,7 @@ final class CredentialValidatorTests: XCTestCase {
     }
 
     func testValidateOpenAIKey_Unauthorized_ReturnsInvalid() async {
-        MockURLProtocol.requestHandler = { request in
+        CredentialValidatorMockURLProtocol.requestHandler = { request in
             let json = """
             {
                 "error": {
@@ -83,7 +83,7 @@ final class CredentialValidatorTests: XCTestCase {
     }
 
     func testValidateOpenAIKey_RateLimited_ReturnsRateLimited() async {
-        MockURLProtocol.requestHandler = { request in
+        CredentialValidatorMockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 429, httpVersion: nil, headerFields: ["retry-after": "15"])!
             return (response, Data())
         }
@@ -93,7 +93,7 @@ final class CredentialValidatorTests: XCTestCase {
     }
 
     func testValidateOpenAIKey_NetworkError_ReturnsInvalid() async {
-        MockURLProtocol.requestHandler = { _ in
+        CredentialValidatorMockURLProtocol.requestHandler = { _ in
             throw NSError(domain: "TestError", code: -1001, userInfo: [NSLocalizedDescriptionKey: "The request timed out."])
         }
 

--- a/OpenConeTests/Services/PineconeServiceHealthCheckTests.swift
+++ b/OpenConeTests/Services/PineconeServiceHealthCheckTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import OpenCone
 
-final class MockURLProtocol: URLProtocol {
+private final class MockURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {

--- a/OpenConeTests/Services/PineconeServiceHealthCheckTests.swift
+++ b/OpenConeTests/Services/PineconeServiceHealthCheckTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import OpenCone
 
-private final class MockURLProtocol: URLProtocol {
+private final class PineconeHealthCheckMockURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -13,7 +13,7 @@ private final class MockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
+        guard let handler = PineconeHealthCheckMockURLProtocol.requestHandler else {
             fatalError("Handler is unavailable.")
         }
 
@@ -36,7 +36,7 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        URLProtocol.registerClass(MockURLProtocol.self)
+        URLProtocol.registerClass(PineconeHealthCheckMockURLProtocol.self)
         // Reset UserDefaults state if necessary for clean tests
         UserDefaults.standard.removeObject(forKey: "pinecone.cachedIndexList")
         UserDefaults.standard.removeObject(forKey: "pineconeCloud")
@@ -44,14 +44,14 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
     }
 
     override func tearDown() {
-        URLProtocol.unregisterClass(MockURLProtocol.self)
-        MockURLProtocol.requestHandler = nil
+        URLProtocol.unregisterClass(PineconeHealthCheckMockURLProtocol.self)
+        PineconeHealthCheckMockURLProtocol.requestHandler = nil
         super.tearDown()
     }
 
     func testHealthCheck_NoIndexSelected() async {
         let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [MockURLProtocol.self]
+        config.protocolClasses = [PineconeHealthCheckMockURLProtocol.self]
         let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
         // indexHost and currentIndex are nil by default
 
@@ -64,11 +64,11 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
     func testHealthCheck_Success() async throws {
 
         let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [MockURLProtocol.self]
+        config.protocolClasses = [PineconeHealthCheckMockURLProtocol.self]
         let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
 
         // Setup handler to mock the index describe response so indexHost is set
-        MockURLProtocol.requestHandler = { request in
+        PineconeHealthCheckMockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             if request.url?.absoluteString.contains("/indexes/") == true {
                 let json = """
@@ -115,10 +115,10 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
 
     func testHealthCheck_ServerError() async throws {
         let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [MockURLProtocol.self]
+        config.protocolClasses = [PineconeHealthCheckMockURLProtocol.self]
         let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
 
-        MockURLProtocol.requestHandler = { request in
+        PineconeHealthCheckMockURLProtocol.requestHandler = { request in
             if request.url?.absoluteString.contains("/indexes/") == true {
                 let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                 let json = """
@@ -159,10 +159,10 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
 
     func testHealthCheck_CircuitOpen() async throws {
         let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [MockURLProtocol.self]
+        config.protocolClasses = [PineconeHealthCheckMockURLProtocol.self]
         let sut = PineconeService(apiKey: "test", projectId: "test", sessionConfiguration: config)
 
-        MockURLProtocol.requestHandler = { request in
+        PineconeHealthCheckMockURLProtocol.requestHandler = { request in
             if request.url?.absoluteString.contains("/indexes/") == true {
                 let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                 let json = """
@@ -192,7 +192,7 @@ final class PineconeServiceHealthCheckTests: XCTestCase {
         XCTAssertTrue(sut.isCircuitOpen)
 
         // Change handler to return 200, but health check should still fail fast because circuit is open
-        MockURLProtocol.requestHandler = { request in
+        PineconeHealthCheckMockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data())
         }

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,6 @@
+🧹 Remove unused localSearch and cosineSimilarity functions
+
+🎯 **What:** The `localSearch` function and its helper `cosineSimilarity` were removed from `OpenCone/Services/EmbeddingService.swift`.
+💡 **Why:** These functions are unused dead code. Removing them improves maintainability and readability without altering the application's behavior.
+✅ **Verification:** Verified with code searches that neither `localSearch` nor `cosineSimilarity` were invoked elsewhere in the codebase.
+✨ **Result:** A cleaner codebase with less dead code.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,6 +1,0 @@
-🧹 Remove unused localSearch and cosineSimilarity functions
-
-🎯 **What:** The `localSearch` function and its helper `cosineSimilarity` were removed from `OpenCone/Services/EmbeddingService.swift`.
-💡 **Why:** These functions are unused dead code. Removing them improves maintainability and readability without altering the application's behavior.
-✅ **Verification:** Verified with code searches that neither `localSearch` nor `cosineSimilarity` were invoked elsewhere in the codebase.
-✨ **Result:** A cleaner codebase with less dead code.


### PR DESCRIPTION
🎯 **What:** The `localSearch` function and its helper `cosineSimilarity` were removed from `OpenCone/Services/EmbeddingService.swift`.
💡 **Why:** These functions are unused dead code. Removing them improves maintainability and readability without altering the application's behavior.
✅ **Verification:** Verified with code searches that neither `localSearch` nor `cosineSimilarity` were invoked elsewhere in the codebase.
✨ **Result:** A cleaner codebase with less dead code.

---
*PR created automatically by Jules for task [3716250227911722201](https://jules.google.com/task/3716250227911722201) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Remove the unused cosine similarity helper and local search functionality from EmbeddingService to reduce dead code.