### PR TITLE
🔒 Fix sensitive data exposure in query error logging

### DIFF
--- a/OpenCone/Services/PineconeService.swift
+++ b/OpenCone/Services/PineconeService.swift
@@ -1180,8 +1180,7 @@ final class PineconeService {
                 do {
                     result = try JSONDecoder().decode(QueryResponse.self, from: data)
                 } catch {
-                    let raw = String(data: data, encoding: .utf8) ?? "<non-utf8 \(data.count) bytes>"
-                    logger.log(level: .error, message: "Pinecone decode error (query). Raw response: \(raw)")
+                    logger.log(level: .error, message: "Pinecone decode error (query). Response size: \(data.count) bytes, Error: \(error.localizedDescription)")
                     throw error
                 }
             } catch {

--- a/OpenConeTests/Core/Security/CredentialValidatorTests.swift
+++ b/OpenConeTests/Core/Security/CredentialValidatorTests.swift
@@ -1,34 +1,7 @@
 import XCTest
 @testable import OpenCone
 
-final class MockURLProtocol: URLProtocol {
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
-    override class func canInit(with request: URLRequest) -> Bool {
-        return true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        return request
-    }
-
-    override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
-            fatalError("Handler is unavailable.")
-        }
-
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
-}
 
 @MainActor
 final class CredentialValidatorTests: XCTestCase {

--- a/OpenConeTests/Mocks/MockURLProtocol.swift
+++ b/OpenConeTests/Mocks/MockURLProtocol.swift
@@ -4,6 +4,7 @@ class MockURLProtocol: URLProtocol {
     static var mockData: Data?
     static var mockResponse: URLResponse?
     static var mockError: Error?
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {
         return true
@@ -14,6 +15,18 @@ class MockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
+        if let handler = MockURLProtocol.requestHandler {
+            do {
+                let (response, data) = try handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+            return
+        }
+
         if let error = MockURLProtocol.mockError {
             client?.urlProtocol(self, didFailWithError: error)
             return
@@ -36,5 +49,6 @@ class MockURLProtocol: URLProtocol {
         mockData = nil
         mockResponse = nil
         mockError = nil
+        requestHandler = nil
     }
 }

--- a/OpenConeTests/Services/PineconeServiceHealthCheckTests.swift
+++ b/OpenConeTests/Services/PineconeServiceHealthCheckTests.swift
@@ -1,35 +1,7 @@
 import XCTest
 @testable import OpenCone
 
-final class MockURLProtocol: URLProtocol {
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
-    override class func canInit(with request: URLRequest) -> Bool {
-        return true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        return request
-    }
-
-    override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
-            fatalError("Handler is unavailable.")
-        }
-
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {
-    }
-}
 
 @MainActor
 final class PineconeServiceHealthCheckTests: XCTestCase {


### PR DESCRIPTION
🎯 **What:** Removed the logging of raw API response data when JSON parsing fails during Pinecone queries.
⚠️ **Risk:** If a query returns sensitive user data but fails to decode properly, the entire raw response would be dumped into the application logs, potentially exposing PII or confidential information.
🛡️ **Solution:** Updated the error log to only include the size of the response data and the localized description of the decoding error.

---
*PR created automatically by Jules for task [12143279442103730814](https://jules.google.com/task/12143279442103730814) started by @Gunnarguy*