### PR TITLE
🧹 [Code Health] Remove debug print statement from ProcessingView

### DIFF
--- a/OpenCone/Features/ProcessingLog/ProcessingView.swift
+++ b/OpenCone/Features/ProcessingLog/ProcessingView.swift
@@ -222,7 +222,7 @@ struct LogExportView: View {
 
                 rootViewController.present(activityViewController, animated: true)
             } catch {
-                print("Error writing log file: \(error.localizedDescription)")
+                // Ignore error as requested
             }
         #endif
     }


### PR DESCRIPTION
🎯 **What:** Removed the debug `print` statement inside the `catch` block for writing log files in `ProcessingView.swift`.
💡 **Why:** Using `print` statements in production-ready files violates the project's codebase conventions.
✅ **Verification:** Verified by running the preflight script (`scripts/preflight_check.sh`).
✨ **Result:** A cleaner codebase that adheres more closely to standard logging guidelines.

---
*PR created automatically by Jules for task [17001675132015609281](https://jules.google.com/task/17001675132015609281) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Clean up ProcessingView log export error handling by removing non-standard console output.