### PR TITLE
🧹 [Code Health] Remove debug print statement from Logger

### DIFF
--- a/OpenCone/Core/Logger.swift
+++ b/OpenCone/Core/Logger.swift
@@ -14,8 +14,6 @@ final class Logger: ObservableObject, Sendable {
         return formatter
     }()
 
-    private static let consoleDateFormatter = ISO8601DateFormatter()
-
     /// Published array of log entries, allowing SwiftUI views to react to changes.
     @Published var logEntries: [ProcessingLogEntry] = []
 
@@ -27,7 +25,6 @@ final class Logger: ObservableObject, Sendable {
 
     /// Adds a log entry with the specified level, message, and optional context.
     /// Updates the `logEntries` array on the main thread for UI safety.
-    /// Also prints the log message to the console for debugging.
     /// - Parameters:
     ///   - level: The severity level of the log entry (e.g., info, warning, error).
     ///   - message: The main content of the log message.
@@ -46,11 +43,6 @@ final class Logger: ObservableObject, Sendable {
             // Efficiently remove oldest entries by creating a new array slice.
             logEntries = Array(logEntries.dropFirst(logEntries.count - maxLogEntries))
         }
-
-        // Also print to the console for real-time debugging during development.
-        let timestamp = Self.consoleDateFormatter.string(from: entry.timestamp)
-        let contextInfo = context.map { " [\($0)]" } ?? "" // Use map for cleaner optional handling.
-        print("[\(timestamp)] [\(level.rawValue)]\(contextInfo): \(message)")
     }
 
     private func currentMinimumLevel() -> ProcessingLogEntry.LogLevel {


### PR DESCRIPTION
🎯 **What:** Removed the debug `print` statement, the unused `consoleDateFormatter` property, and updated the documentation in `Logger.swift`.
💡 **Why:** To improve code health and cleanliness by removing unnecessary console prints that were intended for development only.
✅ **Verification:** Verified by running `python3 scripts/secret_scan.py` to ensure no secrets were accidentally introduced, and checking the `git status` and `git diff` outputs. Standard XCTest verification was bypassed as it is not available in the container environment. The code review tool indicated the fix was complete and correct without causing any side effects.
✨ **Result:** Cleaned up `Logger.swift` by removing unused debug code, making it strictly append log entries safely to the array.

---
*PR created automatically by Jules for task [16004318205411872954](https://jules.google.com/task/16004318205411872954) started by @Gunnarguy*

## Summary by Sourcery

Clean up Logger by removing development-only console logging and related unused date formatter.

Enhancements:
- Remove unused consoleDateFormatter property from Logger.
- Stop printing log entries to the console, keeping Logger focused on maintaining the in-memory log array.
- Update Logger documentation comments to reflect removal of console debugging behavior.