### PR TITLE
🧹 [code health] Remove debug print statement in WelcomeView

### DIFF
--- a/OpenCone/App/WelcomeView.swift
+++ b/OpenCone/App/WelcomeView.swift
@@ -517,6 +517,5 @@ struct APIKeyEntryView: View {
     // Provides a preview instance of the WelcomeView in Xcode Canvas.
     WelcomeView(settingsViewModel: SettingsViewModel()) {
         // Action to perform when the preview setup completes.
-        print("Setup completed in Preview")
     }
 }


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary `print("Setup completed in Preview")` statement from the `#Preview` block in `OpenCone/App/WelcomeView.swift`.
💡 **Why:** Debug print statements in previews are unnecessary and clutter the code. Removing them improves code readability and health.
✅ **Verification:** Verified by inspecting the change using `cat` and running `preflight_check.sh` (with tests bypassed due to the Linux execution environment missing `xcodebuild`). The change was also reviewed and confirmed to be safe and perfectly correct by the AI code reviewer.
✨ **Result:** The codebase is slightly cleaner and more maintainable with the removal of this trivial print statement.

---
*PR created automatically by Jules for task [12272295055947074632](https://jules.google.com/task/12272295055947074632) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Simplify the WelcomeView preview by removing a non-essential debug log statement.