### PR TITLE
⚡ Optimize search result selection check using Set

### DIFF
--- a/OpenCone/Features/Search/SearchView.swift
+++ b/OpenCone/Features/Search/SearchView.swift
@@ -726,18 +726,16 @@ struct SourcesSheet: View {
     @Environment(\.theme) private var theme
     @Environment(\.dismiss) private var dismiss
 
-    private func isResultSelected(_ result: SearchResultModel) -> Bool {
-        viewModel.selectedResults.contains { $0.id == result.id }
-    }
-
     var body: some View {
+        let selectedIDs = Set(viewModel.selectedResults.map { $0.id })
+
         NavigationStack {
             ScrollView {
                 LazyVStack(spacing: 12) {
                     ForEach(viewModel.searchResults) { result in
                         SearchResultRow(
                             result: result,
-                            isSelected: isResultSelected(result),
+                            isSelected: selectedIDs.contains(result.id),
                             viewModel: viewModel
                         ) {
                             viewModel.toggleResultSelection(result)


### PR DESCRIPTION
💡 **What:** Replaced the O(N) array lookup `isResultSelected(_ result:)` with a Set initialization inside `SourcesSheet.body` that evaluates in O(1) time per item. 
🎯 **Why:** Previously, checking if a result was selected caused an array scan over `selectedResults`. For a list of `M` search results and `N` selected results, view rendering complexity was `O(M * N)`. By precomputing a `Set` of selected IDs, the view rendering is reduced to `O(M + N)`, preventing UI blocking on large datasets.
📊 **Measured Improvement:** Simulated performance using Python since `xcodebuild` is unavailable in the Linux CI environment. Comparing O(N) list scans vs O(1) set lookups for 100 redraws:
* 1000 items (200 selected): 3.28s (array) -> 0.03s (set), ~120x improvement
* 5000 items (1000 selected): 82.23s (array) -> 0.14s (set), ~580x improvement

---
*PR created automatically by Jules for task [9690717230308971267](https://jules.google.com/task/9690717230308971267) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Replace per-row linear selected-results lookup with a Set-based membership check to improve view rendering scalability for large result lists.