### PR TITLE
🔒 [Security] Update Keychain accessibility to WhenUnlocked

### DIFF
--- a/OpenCone/Core/Security/SecureSettingsStore.swift
+++ b/OpenCone/Core/Security/SecureSettingsStore.swift
@@ -149,7 +149,7 @@ final class SecureSettingsStore: @unchecked Sendable {
         ]
 
         // Improve accessibility as needed (default generic)
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
 
         let status = SecItemAdd(addQuery as CFDictionary, nil)
         return status == errSecSuccess


### PR DESCRIPTION
🎯 **What:** Changed `kSecAttrAccessibleAfterFirstUnlock` to `kSecAttrAccessibleWhenUnlocked` for Keychain storage.
⚠️ **Risk:** Allowing access after first unlock exposes stored credentials even when the device is locked, increasing the risk of data compromise if the device is exploited.
🛡️ **Solution:** `kSecAttrAccessibleWhenUnlocked` ensures that the credentials are only accessible while the device is unlocked, aligning with security best practices.

---
*PR created automatically by Jules for task [2039882972407734997](https://jules.google.com/task/2039882972407734997) started by @Gunnarguy*

## Summary by Sourcery

Enhancements:
- Update SecureSettingsStore to use kSecAttrAccessibleWhenUnlocked for Keychain entries instead of allowing access after first unlock.