### PR TITLE
🧪 Add unit tests for ProcessingLogEntry LogLevel colors

### DIFF
--- a/OpenConeTests/Core/ProcessingLogEntryTests.swift
+++ b/OpenConeTests/Core/ProcessingLogEntryTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import SwiftUI
+@testable import OpenCone
+
+final class ProcessingLogEntryTests: XCTestCase {
+
+    func testLogLevelColorWithoutTheme() {
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.debug.color(for: nil), .gray)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.info.color(for: nil), .blue)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.warning.color(for: nil), .orange)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.error.color(for: nil), .red)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.success.color(for: nil), .green)
+    }
+
+    func testLogLevelColorWithTheme() {
+        let theme = OCTheme.forest
+
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.debug.color(for: theme), .gray)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.info.color(for: theme), theme.primaryColor)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.warning.color(for: theme), .orange)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.error.color(for: theme), theme.errorColor)
+        XCTAssertEqual(ProcessingLogEntry.LogLevel.success.color(for: theme), .green)
+    }
+
+    func testLegacyColorProperty() {
+        let debugColor: Color = ProcessingLogEntry.LogLevel.debug.color
+        XCTAssertEqual(debugColor, .gray)
+
+        let infoColor: Color = ProcessingLogEntry.LogLevel.info.color
+        XCTAssertEqual(infoColor, .blue)
+
+        let warningColor: Color = ProcessingLogEntry.LogLevel.warning.color
+        XCTAssertEqual(warningColor, .orange)
+
+        let errorColor: Color = ProcessingLogEntry.LogLevel.error.color
+        XCTAssertEqual(errorColor, .red)
+
+        let successColor: Color = ProcessingLogEntry.LogLevel.success.color
+        XCTAssertEqual(successColor, .green)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the untested log level color logic within `ProcessingLogEntry.swift`. The `color(for:)` function and its related legacy `color` property lacked test coverage despite being pure functions easily testable.

📊 **Coverage:** What scenarios are now tested
- The `color(for:)` function behavior for all cases (`.debug`, `.info`, `.warning`, `.error`, `.success`) without a theme provided.
- The `color(for:)` function behavior for all cases with an injected `OCTheme`.
- The legacy `color` property to ensure it remains functionally equivalent to `color(for: nil)`.

✨ **Result:** The improvement in test coverage
The code reliability is improved with complete 100% coverage on the log level color logic in `ProcessingLogEntry.swift`.

---
*PR created automatically by Jules for task [12272295055947073751](https://jules.google.com/task/12272295055947073751) started by @Gunnarguy*

## Summary by Sourcery

Add unit tests covering ProcessingLogEntry.LogLevel color behavior.

Tests:
- Add tests for log level colors without a theme.
- Add tests for log level colors when an OCTheme is provided.
- Add tests verifying the legacy color property matches color(for: nil).