### PR TITLE
🔒 [security fix] Enforce maximum payload size limit in CredentialValidator

### DIFF
--- a/OpenCone/Core/Security/CredentialValidator.swift
+++ b/OpenCone/Core/Security/CredentialValidator.swift
@@ -79,6 +79,7 @@ final class CredentialValidator: Sendable {
 
     private func decodeOpenAIErrorMessage(_ data: Data) -> String? {
         struct OpenAIErrorResponse: Decodable { let error: Inner; struct Inner: Decodable { let message: String } }
+        guard data.count <= 10 * 1024 else { return nil }
         if let decoded = try? JSONDecoder().decode(OpenAIErrorResponse.self, from: data) {
             return decoded.error.message
         }
@@ -143,6 +144,7 @@ final class CredentialValidator: Sendable {
 
     private func decodePineconeErrorMessage(_ data: Data) -> String? {
         struct PineconeErrorResponse: Decodable { let message: String? }
+        guard data.count <= 10 * 1024 else { return nil }
         if let decoded = try? JSONDecoder().decode(PineconeErrorResponse.self, from: data) {
             return decoded.message
         }

--- a/OpenConeTests/Core/Security/CredentialValidatorPineconeTests.swift
+++ b/OpenConeTests/Core/Security/CredentialValidatorPineconeTests.swift
@@ -72,4 +72,15 @@ final class CredentialValidatorPineconeTests: XCTestCase {
         let status = await validator.validatePinecone(apiKey: "pcsk_test", projectId: "test-proj")
         XCTAssertEqual(status, .invalid(message: "Network error: The Internet connection appears to be offline."))
     }
+
+    func testValidatePinecone_largePayload_returnsInvalid() async {
+        let url = URL(string: "https://api.pinecone.io/indexes")!
+        MockURLProtocol.mockResponse = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
+
+        // Create a payload larger than 10KB
+        MockURLProtocol.mockData = Data(repeating: 0x20, count: 11 * 1024)
+
+        let status = await validator.validatePinecone(apiKey: "pcsk_invalid", projectId: "test-proj")
+        XCTAssertEqual(status, .invalid(message: "Unauthorized: Invalid API key or Project ID"))
+    }
 }

--- a/OpenConeTests/Core/Security/CredentialValidatorTests.swift
+++ b/OpenConeTests/Core/Security/CredentialValidatorTests.swift
@@ -100,4 +100,16 @@ final class CredentialValidatorTests: XCTestCase {
         let status = await sut.validateOpenAIKey("sk-testkey")
         XCTAssertEqual(status, .invalid(message: "Network error: The request timed out."))
     }
+
+    func testValidateOpenAIKey_LargePayload_ReturnsInvalid() async {
+        CredentialValidatorMockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            // Create a payload larger than 10KB
+            let largeData = Data(repeating: 0x20, count: 11 * 1024)
+            return (response, largeData)
+        }
+
+        let status = await sut.validateOpenAIKey("sk-testkey")
+        XCTAssertEqual(status, .invalid(message: "Unauthorized: Invalid API key"))
+    }
 }


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability in `CredentialValidator.swift` where an unboundedly large or maliciously crafted external JSON payload could cause a Denial of Service (DoS) through memory exhaustion or CPU spikes.

⚠️ **Risk:** The previous implementation attempted to parse the API error response indiscriminately using `JSONDecoder()`. An oversized payload (e.g., Megabytes or Gigabytes of data) returned by a compromised or spoofed endpoint could freeze the application and exhaust device memory.

🛡️ **Solution:** Enforced a strict 10 KB (`10 * 1024` bytes) maximum payload size limit before attempting to decode JSON in both `decodePineconeErrorMessage` and `decodeOpenAIErrorMessage`. Payloads exceeding this limit return `nil`, gracefully falling back to the standard, generic error message (e.g., "Unauthorized"). Added accompanying unit tests.

---
*PR created automatically by Jules for task [1898449743094952255](https://jules.google.com/task/1898449743094952255) started by @Gunnarguy*

## Summary by Sourcery

Enforce a maximum payload size when decoding external error responses in the credential validation flow to prevent large responses from impacting app stability.

Bug Fixes:
- Mitigate potential denial-of-service from oversized OpenAI and Pinecone error response payloads by rejecting data over the configured size limit.

Enhancements:
- Limit JSON decoding in OpenAI and Pinecone error message helpers to payloads of at most 10 KB, falling back to generic unauthorized messages for larger payloads.

Tests:
- Add unit tests verifying that oversized OpenAI and Pinecone error payloads result in invalid credential status with the expected generic unauthorized error messages.